### PR TITLE
changes to resolve errors in look_for_format

### DIFF
--- a/trc2bids/functions/create_electrodes_tsv.m
+++ b/trc2bids/functions/create_electrodes_tsv.m
@@ -125,7 +125,7 @@ if ~isempty(electrodes_tsv)
             
             cc_elec_old = readtable(filename,'FileType','text','Delimiter','\t');
             
-            if any(cc_elec_old.x ~= 0) % electrode positions has been added
+            if any(str2double(cc_elec_old.x) ~= 0) % electrode positions has been added
                 
                 % if number of electrodes is changed and electrode
                     % positions x y z are filled in, these positions should be

--- a/trc2bids/functions/extract_metadata_from_annotations.m
+++ b/trc2bids/functions/extract_metadata_from_annotations.m
@@ -65,20 +65,6 @@ try
         end
     end
     
-    %% ---------- FORMAT ----------
-    format_idx=cellfun(@(x) contains(x,{'Format'}),annots(:,2));
-    if(sum(format_idx)<1)
-        file = dir(fullfile(cfg(2).proj_dirinput,patName,['ses-',metadata.ses_name],'ieeg','*ieeg.json'));
-        if ~isempty(file)
-            ieeg_json = jsondecode(fileread([file(1).folder '/' file(1).name]) );
-            metadata.format_info = ieeg_json.iEEGElectrodeGroups;
-        else
-            error('Missing Format annotation, and no other json from other ECoG with format annotation found')
-        end
-    else
-        metadata = look_for_format(metadata,format_idx,annots);
-    end    
-    
     %% ---------- INCLUDED ----------
     included_idx=cellfun(@(x) contains(x,{'Included'}),annots(:,2));
     
@@ -100,6 +86,20 @@ try
         end
         
     end
+    
+    %% ---------- FORMAT ----------
+    format_idx=cellfun(@(x) contains(x,{'Format'}),annots(:,2));
+    if (sum(format_idx)<1)
+        file = dir(fullfile(cfg(2).proj_dirinput,patName,['ses-',metadata.ses_name],'ieeg','*ieeg.json'));
+        if ~isempty(file)
+            ieeg_json = jsondecode(fileread([file(1).folder '/' file(1).name]) );
+            metadata.format_info = ieeg_json.iEEGElectrodeGroups;
+        else
+            error('Missing Format annotation, and no other json from other ECoG with format annotation found')
+        end
+    else
+        metadata = look_for_format(metadata,format_idx,annots);
+    end        
     
     %% ---------- ELECTRODE MODEL ----------
     elecmodel_idx=cellfun(@(x) contains(x,{'Elec_model'}),annots(:,2));


### PR DESCRIPTION
Ha Sifra,

ik had hier ook over gemaild. Ik heb het anders opgelost. In included staat namelijk welke C elektrodes er data bevatten, en dat anderen noise hebben. Dus ik gebruik nu de elektrodes die in ch2use staan om alleen die elektrodes die data bevatten te checken.
Volgens mij moet dit nu nog steeds werken voor alle patienten. Ik ga dus jouw pullrequest afsluiten en zometeen mijn pullrequest erop zetten. Ik check het eerst nog even op wat patienten. Ook heb ik nog een dingetje opgelost in een patient die C[4x8,4x8] had. Daar werd format nu ook niet goed uitgerekend, maar nu wel.

Groetjes!
